### PR TITLE
[Feat] 상품 삭제/수정 시 Storage 이미지 삭제 처리

### DIFF
--- a/src/lib/product/hooks/useDeleteProduct.ts
+++ b/src/lib/product/hooks/useDeleteProduct.ts
@@ -1,17 +1,12 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { doc, deleteDoc } from "firebase/firestore";
-import { db } from "@/firebase";
 import { QUERY_KEYS } from "@/lib/queryKeys";
+import { deleteProductAPI } from "../api";
 
 export const useDeleteProduct = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (productId: string) => {
-      const productRef = doc(db, "products", productId);
-      await deleteDoc(productRef);
-      return productId;
-    },
+    mutationFn: deleteProductAPI,
     onSuccess: (productId) => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEYS.PRODUCTS] });
       queryClient.invalidateQueries({


### PR DESCRIPTION
## PR 제목 
상품 삭제/수정 시 Storage에 저장된 이미지 파일도 삭제 되도록 처리

## ✅ 작업 사항
- **상품 삭제 시 Storage 이미지 삭제 (deleteProductAPI)** 
  - 상품 데이터를 삭제하기 전에 해당 상품에 연결된 이미지 파일을 Storage에서 삭제하도록 구현
- **상품 수정 시 Storage 이미지 삭제 (updateProductAPI)**
  - 상품 수정 시 기존에 저장된 이미지와 수정된 이미지의 URL 목록 비교
  - 삭제된 이미지를 Storage에서 삭제하도록 구현
- 콘솔 메세지
  - `DELETE ~ 404 (Not Found) `
  - 해당 이미지가 이미 Storage에서 삭제된 경우 발생하는 메세지

## 🔔 관련 이슈
close #41 
