### PR TITLE
[Refactor] 이미지 최적화 - 압축 및 Webp 변환 적용

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@radix-ui/react-switch": "^1.1.1",
         "@tanstack/react-query": "^5.59.15",
         "@tanstack/react-query-devtools": "^5.59.19",
+        "browser-image-compression": "^2.0.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "embla-carousel-react": "^8.3.0",
@@ -3288,6 +3289,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/browser-image-compression": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/browser-image-compression/-/browser-image-compression-2.0.2.tgz",
+      "integrity": "sha512-pBLlQyUf6yB8SmmngrcOw3EoS4RpQ1BcylI3T9Yqn7+4nrQTXJD4sJDe5ODnJdrvNMaio5OicFo75rDyJD2Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "uzip": "0.20201231.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
@@ -6035,6 +6045,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/uzip": {
+      "version": "0.20201231.0",
+      "resolved": "https://registry.npmjs.org/uzip/-/uzip-0.20201231.0.tgz",
+      "integrity": "sha512-OZeJfZP+R0z9D6TmBgLq2LHzSSptGMGDGigGiEe0pr8UBe/7fdflgHlHBNDASTXB5jnFuxHpNaJywSg8YFeGng==",
       "license": "MIT"
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@radix-ui/react-switch": "^1.1.1",
     "@tanstack/react-query": "^5.59.15",
     "@tanstack/react-query-devtools": "^5.59.19",
+    "browser-image-compression": "^2.0.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "embla-carousel-react": "^8.3.0",

--- a/src/lib/product/utils.ts
+++ b/src/lib/product/utils.ts
@@ -1,0 +1,37 @@
+import { storage } from "@/firebase";
+import imageCompression from "browser-image-compression";
+import {
+  deleteObject,
+  getDownloadURL,
+  ref,
+  uploadBytes,
+} from "firebase/storage";
+
+const imageCompressionOptions = {
+  maxSizeMB: 1,
+  maxWidthOrHeight: 800,
+  useWebWorker: true,
+  fileType: "image/webp",
+};
+
+export const compressAndConvertImage = async (file: File): Promise<Blob> => {
+  return await imageCompression(file, imageCompressionOptions);
+};
+
+export const uploadImageToFirebase = async (
+  file: Blob,
+  fileName: string
+): Promise<string> => {
+  const storageRef = ref(storage, `images/${fileName}.webp`);
+  await uploadBytes(storageRef, file);
+  return await getDownloadURL(storageRef);
+};
+
+export const deleteImageFormFirebaes = async (url: string): Promise<void> => {
+  const imageRef = ref(storage, url);
+  try {
+    await deleteObject(imageRef);
+  } catch (error) {
+    console.error(`이미지 삭제 실패: ${url}`, error);
+  }
+};


### PR DESCRIPTION
## PR 제목 
이미지 최적화 - 압축 및 Webp 변환 적용

## ✅ 작업 사항
- **이미지 압축 및 변환** 
  - `browser-image-compression` 라이브러리 사용
  - `compressAndConvertImage`: 이미지를 압축하고 Webp 형식으로 변환된 Blob 파일 생성
  -  1MB 이하의 Webp 파일로 압축, 크기를 최대 800px로 제한
- **미리보기 및 Firebase Storage 업로드 과정 통합**
  - 최적화된 Blob 파일을 통해 미리보기와 업로드를 한번에 처리
- **성능 개선**
  - **총 용량 감소**: 225.9 MB → 101.95 MB로 **약 55%** Storage 용량 감소
  - **개별 이미지 크기 감소**: 큰 이미지들이 1MB 이상에서 **100 KB 이하**로 줄어듦
  - **최대 로드 시간 감소**: 801ms → 606ms로 **약 24.3%**** 감소

## 🔔 관련 이슈
close #37 
