### PR TITLE
[Fix] dist 경로 지정을 통한 빌드 후 출력 파일 에러 해결

### DIFF
--- a/apps/bookmark/vercel.json
+++ b/apps/bookmark/vercel.json
@@ -2,7 +2,14 @@
   "builds": [
     {
       "src": "apps/bookmark/package.json",
-      "use": "@vercel/node"
+      "use": "@vercel/node",
+      "config": { "distDir": "apps/bookmark/dist" }
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "apps/bookmark/dist/$1"
     }
   ],
   "env": {

--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["$TURBO_DEFAULT$", ".env*"],
-      "outputs": ["apps/bookmark/dist/**", "packages/ui/dist/**"]
+      "outputs": ["apps/bookmark/dist/**"]
     },
     "lint": {
       "dependsOn": ["^lint"]


### PR DESCRIPTION
## PR 제목 
dist 경로 지정을 통한 빌드 후 출력 파일

## ✅ 작업 사항
- 문제 
  - Vercel 배포 시 `No Output Directory named 'dist' found after the Build completed` 오류 발생 
  - Vercel이 올바른 빌드 경로를 찾지 못하는 문제 
- 해결 
  - `vercel.json` 수정
    - `"distDir": "apps/bookmark/dist"`: dist 디렉토리의 위치를 명시하여 올바른 디렉토리를 참조하도록 함
    - `"routes" 설정: routes 옵션을 통해 빌드 후 생성된 파일들이 배포될 경로를 구체적으로 지정  
  - `turbo.json` 수정
    -  `outputs`항목에 `apps/bookmark/dist/**`를 명확하게 설정

## 🔔 관련 이슈
close #67 
