### PR TITLE
[DesignSystem] Modal 컴포넌트에 Controlled 기능 추가

### DIFF
--- a/packages/design-system/.storybook/main.ts
+++ b/packages/design-system/.storybook/main.ts
@@ -1,7 +1,8 @@
 import type { StorybookConfig } from "@storybook/react-vite";
+import { mergeConfig } from "vite";
 
 const config: StorybookConfig = {
-  stories: ["../src/**/*.stories.@(ts|tsx|mdx)"],
+  stories: ["../src/**/*.stories.@(ts|tsx)"],
   addons: [
     "@storybook/addon-onboarding",
     "@storybook/addon-essentials",
@@ -20,6 +21,14 @@ const config: StorybookConfig = {
   },
   core: {
     builder: "@storybook/builder-vite",
+  },
+  async viteFinal(config) {
+    return mergeConfig(config, {
+      optimizeDeps: {
+        include: ["storybook-addon"],
+      },
+      plugins: [require("@vitejs/plugin-react")()],
+    });
   },
 };
 export default config;

--- a/packages/design-system/src/modal/Modal.stories.tsx
+++ b/packages/design-system/src/modal/Modal.stories.tsx
@@ -1,11 +1,34 @@
-import React from 'react'
+import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { ModalProvider } from "./ModalContext";
 import Modal from "./components/Modal";
+import Button from "../button/Button";
 
 const meta: Meta = {
   title: "Design System/Modal",
   component: Modal,
+  argTypes: {
+    open: {
+      description: "제어 모드에서 모달의 열림 상태를 설정합니다.",
+      table: {
+        type: { summary: "boolean" },
+      },
+    },
+    onOpenChange: {
+      action: "onOpenChange",
+      description: "제어 모드에서 모달의 상태가 변경될 때 호출되는 함수입니다.",
+      table: {
+        type: { summary: "function" },
+      },
+    },
+    onClick: {
+      action: "onClick",
+      description: "Modal.Action 버튼 클릭 시 호출되는 함수입니다.",
+      table: {
+        type: { summary: "function" },
+      },
+    },
+  },
   tags: ["autodocs"],
   decorators: [
     (Story) => (
@@ -43,12 +66,12 @@ export const Basic: Story = {
         <Modal.Description>
           This is a description of the modal content.
         </Modal.Description>
-        <div className="flex justify-center gap-2">
+        <Modal.Actions>
           <Modal.Cancel>Cancel</Modal.Cancel>
           <Modal.Action onClick={() => alert("Confirmed")}>
             Confirm
           </Modal.Action>
-        </div>
+        </Modal.Actions>
       </Modal.Content>
     </Modal>
   ),
@@ -63,7 +86,9 @@ export const CancelOnly: Story = {
         <Modal.Description>
           This modal has only a Cancel button to close it.
         </Modal.Description>
-        <Modal.Cancel>Confirm</Modal.Cancel>
+        <Modal.Actions>
+          <Modal.Cancel>Confirm</Modal.Cancel>
+        </Modal.Actions>
       </Modal.Content>
     </Modal>
   ),
@@ -78,7 +103,7 @@ export const CustomPriority: Story = {
         <Modal.Description>
           This modal demonstrates different priority levels for Button.
         </Modal.Description>
-        <div className="flex justify-center gap-2">
+        <Modal.Actions>
           <Modal.Cancel priority="important">Back</Modal.Cancel>
           <Modal.Action
             priority="important"
@@ -86,8 +111,38 @@ export const CustomPriority: Story = {
           >
             Proceed
           </Modal.Action>
-        </div>
+        </Modal.Actions>
       </Modal.Content>
     </Modal>
   ),
+};
+
+export const ControlledModal: Story = {
+  render: () => {
+    const [isModalOpen, setModalOpen] = React.useState(false);
+
+    const openModal = () => setModalOpen(true);
+    const closeModal = () => setModalOpen(false);
+
+    const handleClickModal = () => {
+      alert("confirmed");
+      closeModal();
+    };
+
+    return (
+      <>
+        <Button onClick={openModal}>Open Controlled Modal</Button>
+        <Modal open={isModalOpen} onOpenChange={setModalOpen}>
+          <Modal.Content>
+            <Modal.Title>Controlled Modal Title</Modal.Title>
+            <Modal.Description>Description</Modal.Description>
+            <Modal.Actions>
+              <Modal.Cancel onOpenChange={closeModal}>Cancel</Modal.Cancel>
+              <Modal.Action onClick={handleClickModal}>Confirm</Modal.Action>
+            </Modal.Actions>
+          </Modal.Content>
+        </Modal>
+      </>
+    );
+  },
 };

--- a/packages/design-system/src/modal/components/Modal.tsx
+++ b/packages/design-system/src/modal/components/Modal.tsx
@@ -7,20 +7,29 @@ import { ModalTitle } from "./ModalTitle";
 import { ModalDescription } from "./ModalDescription";
 import { ModalCancel } from "./ModalCancel";
 import { ModalAction } from "./ModalAction";
+import { ModalRootProps } from "../types";
+import { ModalActions } from "./ModalActions";
 
-const Modal: React.FC<{ children: React.ReactNode }> & {
+const Modal: React.FC<ModalRootProps> & {
   Trigger: typeof ModalTrigger;
   Content: typeof ModalContent;
   Title: typeof ModalTitle;
   Description: typeof ModalDescription;
+  Actions: typeof ModalActions;
   Cancel: typeof ModalCancel;
   Action: typeof ModalAction;
-} = ({ children }) => {
-  const { isOpen, closeModal } = useModalContext();
+} = ({ open: controlledOpen, onOpenChange, children }) => {
+  const { isOpen: contextIsOpen, closeModal } = useModalContext();
+
+  const isOpen = controlledOpen !== undefined ? controlledOpen : contextIsOpen;
 
   const handleOverlayClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
-      closeModal();
+      if (onOpenChange) {
+        onOpenChange(false);
+      } else {
+        closeModal();
+      }
     }
   };
 
@@ -51,6 +60,7 @@ Modal.Trigger = ModalTrigger;
 Modal.Content = ModalContent;
 Modal.Title = ModalTitle;
 Modal.Description = ModalDescription;
+Modal.Actions = ModalActions;
 Modal.Cancel = ModalCancel;
 Modal.Action = ModalAction;
 

--- a/packages/design-system/src/modal/components/ModalActions.tsx
+++ b/packages/design-system/src/modal/components/ModalActions.tsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { StyledModalActions } from "../styles";
+import { ModalCancel } from "./ModalCancel";
+import { ModalAction } from "./ModalAction";
+import { ModalActionsProps } from "../types";
+
+export const ModalActions: React.FC<ModalActionsProps> = ({ children }) => {
+  const buttonCount = React.Children.toArray(children).filter(
+    (child) =>
+      React.isValidElement(child) &&
+      (child.type === ModalCancel || child.type === ModalAction)
+  ).length;
+
+  return (
+    <StyledModalActions buttonCount={buttonCount}>
+      {children}
+    </StyledModalActions>
+  );
+};

--- a/packages/design-system/src/modal/components/ModalCancel.tsx
+++ b/packages/design-system/src/modal/components/ModalCancel.tsx
@@ -3,17 +3,25 @@ import { ModalCancelProps } from "../types";
 import { useModalContext } from "../ModalContext";
 import Button from "../../button/Button";
 
-
 export const ModalCancel: React.FC<ModalCancelProps> = ({
   children = "Cancel",
   className,
   priority = "default",
+  onOpenChange,
 }) => {
   const { closeModal } = useModalContext();
 
+  const handleClose = () => {
+    if (onOpenChange) {
+      onOpenChange(false);
+    } else {
+      closeModal();
+    }
+  };
+
   return (
     <Button
-      onClick={closeModal}
+      onClick={handleClose}
       className={className}
       variant="outline"
       priority={priority}

--- a/packages/design-system/src/modal/styles.ts
+++ b/packages/design-system/src/modal/styles.ts
@@ -23,6 +23,7 @@ export const StyledModalContent = styled.div`
   padding: 20px;
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 20px;
 `;
 
@@ -34,4 +35,10 @@ export const StyledModalTitle = styled.p`
 export const StyledModalDescription = styled.p`
   font-size: ${typography.fontSizeMD};
   color: ${palette.gray[700]};
+`;
+
+export const StyledModalActions = styled.div<{ buttonCount: number }>`
+  display: flex;
+  justify-content: center;
+  gap: ${({ buttonCount }) => (buttonCount === 2 ? "8px" : "0")};
 `;

--- a/packages/design-system/src/modal/types.ts
+++ b/packages/design-system/src/modal/types.ts
@@ -7,8 +7,9 @@ export interface ModalContextType {
 }
 
 export interface ModalRootProps {
+  open?: boolean;
+  onOpenChange?: (isOpen: boolean) => void;
   children: React.ReactNode;
-  className?: string;
 }
 
 export interface ModalTriggerProps {
@@ -30,10 +31,15 @@ export interface ModalDescriptionProps {
   className?: string;
 }
 
+export interface ModalActionsProps {
+  children: React.ReactNode;
+}
+
 export interface ModalCancelProps {
   children?: React.ReactNode;
   className?: string;
   priority?: ButtonPriority;
+  onOpenChange?: (isOpen: boolean) => void;
 }
 
 export interface ModalActionProps {


### PR DESCRIPTION
## PR 제목 
Modal 컴포넌트에 Controlled 기능 추가

## ✅ 작업 사항
- 기존 Modal 컴포넌트: 비제어(unControlled) Modal
  - 내부에서 모달의 상태를 자동으로 관리 
  - Trigger를 통해 버튼을 누르면 Modal이 열림 
  - 외부에서 제어할 수 없음
- 제어(Controlled) Modal 구현
  - 사용자(부모 컴포넌트)가 Modal의 상태를 직접 관리하도록 구현
  - `open`과   `onOpenChange` 상태를 props로 받음
- **최종 Modal 컴포넌트** 
  - 제어 Modal: `open`과 `onOpenChange`로 부모 컴포넌트에서 상태를 제어
  - 비제어 Modal: 위의 속성이 없으면 `useModalContext`에서 관리하는 비제어 상태로 작동  

## 🔔 관련 이슈
close #69 
